### PR TITLE
Update ziggy-js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "ziggy-js": "^2.2.1"
+            },
             "devDependencies": {
                 "@headlessui/react": "^2.0.0",
                 "@inertiajs/react": "^1.0.0",
@@ -3563,6 +3566,25 @@
             },
             "engines": {
                 "node": ">= 14"
+            }
+        },
+        "node_modules/ziggy-js": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ziggy-js/-/ziggy-js-2.2.1.tgz",
+            "integrity": "sha512-iIYCxSfe3oentcccKjcrtQa2FJHXYSZjgBa8FfFCgbdK174AsQ9KpqoWjRu2x9U0pJBgviXBdmf4vSM1gqkVZA==",
+            "dependencies": {
+                "qs": "~6.9.7"
+            }
+        },
+        "node_modules/ziggy-js/node_modules/qs": {
+            "version": "6.9.7",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+            "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
         "tailwindcss": "^3.2.1",
         "typescript": "^5.0.2",
         "vite": "^5.0"
+    },
+    "dependencies": {
+        "ziggy-js": "^2.2.1"
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,7 @@
         "forceConsistentCasingInFileNames": true,
         "noEmit": true,
         "paths": {
-            "@/*": ["./resources/js/*"],
-            "ziggy-js": ["./vendor/tightenco/ziggy"]
+            "@/*": ["./resources/js/*"]
         }
     },
     "include": ["resources/js/**/*.ts", "resources/js/**/*.tsx", "resources/js/**/*.d.ts"]


### PR DESCRIPTION
fix #6

This pull request updates the ziggy-js dependency to version 2.2.1. The previous version was removed from the ./vendor directory and the new version was added from npm. Additionally, the tsconfig.json file was modified to remove the reference to the old ziggy-js version in the vendor directory.