### PR TITLE
Expose asset directories and set build directory to default

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,8 +4,15 @@
     "functions": {
         "api/index.php": { "runtime": "vercel-php@0.6.2" }
     },
-    "outputDirectory": "public/build",
     "routes": [
+        {
+            "src": "/(favicon.ico|robots.txt)",
+            "dest": "/$1"
+        },
+        {
+            "src": "/build/(.*)",
+            "dest": "/build/$1"
+        },
         {
             "src": "/(.*)",
             "dest": "/api/index.php"


### PR DESCRIPTION
fix #9

This pull request includes changes to expose asset directories and set the build directory to the default value. The previous configuration had the output directory set to "public/build", but it has been removed in this PR. Additionally, the routes configuration has been updated to handle requests for favicon.ico, robots.txt, and files in the build directory.