### PR TITLE
Update app name display in layouts and welcome page

### DIFF
--- a/resources/js/Layouts/AuthenticatedLayout.tsx
+++ b/resources/js/Layouts/AuthenticatedLayout.tsx
@@ -6,6 +6,8 @@ import ResponsiveNavLink from '@/Components/ResponsiveNavLink';
 import { Link } from '@inertiajs/react';
 import { User } from '@/types';
 
+const appName = process.env.APP_NAME || import.meta.env.VITE_APP_NAME || 'Laravel';
+
 export default function Authenticated({ user, header, children }: PropsWithChildren<{ user: User, header?: ReactNode }>) {
     const [showingNavigationDropdown, setShowingNavigationDropdown] = useState(false);
 
@@ -28,7 +30,7 @@ export default function Authenticated({ user, header, children }: PropsWithChild
                             </div>
                         </div>
 
-                        <h1 className="text-2xl font-semibold text-gray-800">{import.meta.env.VITE_APP_NAME}</h1>
+                        <h1 className="text-2xl font-semibold text-gray-800">{appName}</h1>
 
                         <div className="hidden sm:flex sm:items-center sm:ms-6">
                             <div className="ms-3 relative">

--- a/resources/js/Layouts/GuestLayout.tsx
+++ b/resources/js/Layouts/GuestLayout.tsx
@@ -2,6 +2,8 @@ import ApplicationLogo from '@/Components/ApplicationLogo';
 import { Link } from '@inertiajs/react';
 import { PropsWithChildren } from 'react';
 
+const appName = process.env.APP_NAME || import.meta.env.VITE_APP_NAME || 'Laravel';
+
 export default function Guest({ children }: PropsWithChildren) {
     return (
         <div className="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100">
@@ -11,7 +13,7 @@ export default function Guest({ children }: PropsWithChildren) {
                 </Link>
             </div>
 
-            <h1 className="text-2xl font-semibold text-gray-800">{import.meta.env.VITE_APP_NAME}</h1>
+            <h1 className="text-2xl font-semibold text-gray-800">{appName}</h1>
 
             <div className="w-full sm:max-w-md mt-6 px-6 py-4 bg-white shadow-md overflow-hidden sm:rounded-lg">
                 {children}

--- a/resources/js/Pages/Welcome.tsx
+++ b/resources/js/Pages/Welcome.tsx
@@ -1,6 +1,8 @@
 import { Link, Head } from '@inertiajs/react';
 import { PageProps } from '@/types';
 
+const appName = process.env.APP_NAME || import.meta.env.VITE_APP_NAME || 'Laravel';
+
 export default function Welcome({ auth, laravelVersion, phpVersion }: PageProps<{ laravelVersion: string, phpVersion: string }>) {
     const handleImageError = () => {
         document.getElementById('screenshot-container')?.classList.add('!hidden');
@@ -47,7 +49,7 @@ export default function Welcome({ auth, laravelVersion, phpVersion }: PageProps<
                             </nav>
                         </header>
 
-                        <h1 className="text-4xl font-semibold text-black dark:text-white">{import.meta.env.VITE_APP_NAME}</h1>
+                        <h1 className="text-4xl font-semibold text-black dark:text-white">{appName}</h1>
 
                         <main className="mt-6">
                             <div className="grid gap-6 lg:grid-cols-2 lg:gap-8">

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -5,7 +5,7 @@ import { createRoot } from 'react-dom/client';
 import { createInertiaApp } from '@inertiajs/react';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 
-const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
+const appName = process.env.APP_NAME || import.meta.env.VITE_APP_NAME || 'Laravel';
 
 createInertiaApp({
     title: (title) => `${title} - ${appName}`,


### PR DESCRIPTION
fix #15

This pull request updates the app name display in the layouts and welcome page. Previously, the app name was fetched from the `import.meta.env.VITE_APP_NAME` variable, but now it falls back to the `process.env.APP_NAME` variable if it is available. This change ensures that the app name is displayed correctly in different environments.